### PR TITLE
Eitan/review

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-export FOLDER="."
-export ORG="tetrate"
-
-export TSB_FQDN="tsb.eitan.cx.tetrate.info"
-export REGISTRY=us-central1-docker.pkg.dev/eitan-tetrate/tsb-repo
-

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+export FOLDER="." # why not make "." the default value if this variable is absent?
+export TSB_FQDN="tsb.eitan.cx.tetrate.info"
+export REGISTRY=us-central1-docker.pkg.dev/eitan-tetrate/tsb-repo
+export ORG="tetrate"
+

--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-export FOLDER="." # why not make "." the default value if this variable is absent?
 export TSB_FQDN="tsb.eitan.cx.tetrate.info"
 export REGISTRY=us-central1-docker.pkg.dev/eitan-tetrate/tsb-repo
-export ORG="tetrate"
 

--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+export FOLDER="."
+export ORG="tetrate"
+
 export TSB_FQDN="tsb.eitan.cx.tetrate.info"
 export REGISTRY=us-central1-docker.pkg.dev/eitan-tetrate/tsb-repo
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# generated *-plane values files
+managementplane_values.yaml
+*-controlplane_values.yaml
+dataplane_values.yaml
+
+# generated jwk files
+*-service-account.jwk
+
+# generated cluster yamls
+cluster-*.yaml
+
+# keys
+*.cnf
+*.crt
+*.csr
+*.key
+
+

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ helm install mp tetrate-tsb-helm/managementplane -n tsb --create-namespace -f ma
 ```sh
 export TSB_FQDN="r150helm.cx.tetrate.info"
 tctl config clusters set helm --tls-insecure --bridge-address $TSB_FQDN:8443
-tctl config users set helm --username admin --password "Tetrate123" --org $ORG
+tctl config users set helm --username admin --password "Tetrate123" --org "tetrate"
 tctl config profiles set helm --cluster helm --username helm
 tctl config profiles set-current helm
 ```

--- a/README.md
+++ b/README.md
@@ -36,11 +36,7 @@ helm repo update
 helm install mp tetrate-tsb-helm/managementplane -n tsb --create-namespace -f managementplane_values.yaml
 ```
 
-## Deploying CP...
-
-Please refer for more details over here: https://docs.tetrate.io/service-bridge/1.5.x/en-us/setup/requirements-and-download, https://docs.tetrate.io/service-bridge/1.5.x/en-us/setup/helm/controlplane
-
-### Connect to MP
+## Connect to MP
 
 ```sh
 export TSB_FQDN="r150helm.cx.tetrate.info"
@@ -58,6 +54,10 @@ NAME       DISPLAY NAME    DESCRIPTION
 tetrate    tetrate
 ```
 
+## Deploying CP...
+
+Please refer for more details over here: https://docs.tetrate.io/service-bridge/1.5.x/en-us/setup/requirements-and-download, https://docs.tetrate.io/service-bridge/1.5.x/en-us/setup/helm/controlplane
+
 ### Prep the `controlplane_values.yaml` and `dataplane_values.yaml`
 
 ```sh
@@ -67,7 +67,7 @@ export REGISTRY="r150helm1tsbacrqasvohujrqvnjp0u.azurecr.io"
 export ORG="tetrate"
 export CLUSTER_NAME="app-cluster1"
 ./prep_controlplane_values.sh
-cat controlplane_values.yaml
+cat "${CLUSTER_NAME}-controlplane_values.yaml"
 ```
 
 ### Install CP using Helm
@@ -75,6 +75,6 @@ cat controlplane_values.yaml
 ```sh
 helm repo add tetrate-tsb-helm 'https://charts.dl.tetrate.io/public/helm/charts/'
 helm repo update
-helm install cp tetrate-tsb-helm/controlplane -n istio-system --create-namespace -f controlplane_values.yaml
+helm install cp tetrate-tsb-helm/controlplane -n istio-system --create-namespace -f "${CLUSTER_NAME}-controlplane_values.yaml"
 helm install dp tetrate-tsb-helm/dataplane -n istio-gateway --create-namespace -f dataplane_values.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Please refer for more details over here: https://docs.tetrate.io/service-bridge/
 ### Prep the certificates using OpenSSL on Linux
 
 ```sh
+export FOLDER="."
+export ORG="tetrate"
 export TSB_FQDN="r150helm.cx.tetrate.info"
 ./certs-gen/certs-gen.sh
 ```
@@ -36,7 +38,6 @@ helm install mp tetrate-tsb-helm/managementplane -n tsb --create-namespace -f ma
 ## Connect to MP
 
 ```sh
-export TSB_FQDN="r150helm.cx.tetrate.info"
 tctl config clusters set helm --tls-insecure --bridge-address $TSB_FQDN:8443
 tctl config users set helm --username admin --password "Tetrate123" --org "tetrate"
 tctl config profiles set helm --cluster helm --username helm
@@ -58,7 +59,8 @@ Please refer for more details over here: https://docs.tetrate.io/service-bridge/
 ### Prep the `controlplane_values.yaml` and `dataplane_values.yaml`
 
 ```sh
-export TSB_FQDN="r150helm.cx.tetrate.info"
+export FOLDER="."
+export ORG="tetrate"
 export REGISTRY="r150helm1tsbacrqasvohujrqvnjp0u.azurecr.io"
 export CLUSTER_NAME="app-cluster1"
 ./prep_controlplane_values.sh

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Please refer for more details over here: https://docs.tetrate.io/service-bridge/
 
 ```sh
 export FOLDER="."
-export ORG="tetrate"
 export TSB_FQDN="r150helm.cx.tetrate.info"
 ./certs-gen/certs-gen.sh
 ```
@@ -22,7 +21,9 @@ The output will consist of:
 ### Prep the `managementplane_values.yaml`
 
 ```sh
+export FOLDER="."
 export REGISTRY="r150helm1tsbacrqasvohujrqvnjp0u.azurecr.io"
+export ORG="tetrate"
 ./prep_managementplane_values.sh
 cat managementplane_values.yaml
 ```
@@ -38,6 +39,7 @@ helm install mp tetrate-tsb-helm/managementplane -n tsb --create-namespace -f ma
 ## Connect to MP
 
 ```sh
+export TSB_FQDN="r150helm.cx.tetrate.info"
 tctl config clusters set helm --tls-insecure --bridge-address $TSB_FQDN:8443
 tctl config users set helm --username admin --password "Tetrate123" --org "tetrate"
 tctl config profiles set helm --cluster helm --username helm
@@ -60,8 +62,9 @@ Please refer for more details over here: https://docs.tetrate.io/service-bridge/
 
 ```sh
 export FOLDER="."
-export ORG="tetrate"
+export TSB_FQDN="r150helm.cx.tetrate.info"
 export REGISTRY="r150helm1tsbacrqasvohujrqvnjp0u.azurecr.io"
+export ORG="tetrate"
 export CLUSTER_NAME="app-cluster1"
 ./prep_controlplane_values.sh
 cat "${CLUSTER_NAME}-controlplane_values.yaml"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Please refer for more details over here: https://docs.tetrate.io/service-bridge/
 ### Prep the certificates using OpenSSL on Linux
 
 ```sh
-export FOLDER="."
 export TSB_FQDN="r150helm.cx.tetrate.info"
 ./certs-gen/certs-gen.sh
 ```
@@ -21,7 +20,6 @@ The output will consist of:
 ### Prep the `managementplane_values.yaml`
 
 ```sh
-export FOLDER="."
 export REGISTRY="r150helm1tsbacrqasvohujrqvnjp0u.azurecr.io"
 export ORG="tetrate"
 ./prep_managementplane_values.sh
@@ -61,7 +59,6 @@ Please refer for more details over here: https://docs.tetrate.io/service-bridge/
 ### Prep the `controlplane_values.yaml` and `dataplane_values.yaml`
 
 ```sh
-export FOLDER="."
 export TSB_FQDN="r150helm.cx.tetrate.info"
 export REGISTRY="r150helm1tsbacrqasvohujrqvnjp0u.azurecr.io"
 export ORG="tetrate"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ The output will consist of:
 
 ```sh
 export REGISTRY="r150helm1tsbacrqasvohujrqvnjp0u.azurecr.io"
-export ORG="tetrate"
 ./prep_managementplane_values.sh
 cat managementplane_values.yaml
 ```
@@ -39,7 +38,7 @@ helm install mp tetrate-tsb-helm/managementplane -n tsb --create-namespace -f ma
 ```sh
 export TSB_FQDN="r150helm.cx.tetrate.info"
 tctl config clusters set helm --tls-insecure --bridge-address $TSB_FQDN:8443
-tctl config users set helm --username admin --password "Tetrate123" --org "tetrate"
+tctl config users set helm --username admin --password "Tetrate123" --org $ORG
 tctl config profiles set helm --cluster helm --username helm
 tctl config profiles set-current helm
 ```
@@ -61,7 +60,6 @@ Please refer for more details over here: https://docs.tetrate.io/service-bridge/
 ```sh
 export TSB_FQDN="r150helm.cx.tetrate.info"
 export REGISTRY="r150helm1tsbacrqasvohujrqvnjp0u.azurecr.io"
-export ORG="tetrate"
 export CLUSTER_NAME="app-cluster1"
 ./prep_controlplane_values.sh
 cat "${CLUSTER_NAME}-controlplane_values.yaml"

--- a/certs-gen/certs-gen.sh
+++ b/certs-gen/certs-gen.sh
@@ -1,3 +1,5 @@
+FOLDER=${FOLDER:-.}
+
 function create_cert() {
   local readonly name=$1
   local readonly folder=$2

--- a/certs-gen/certs-gen.sh
+++ b/certs-gen/certs-gen.sh
@@ -1,5 +1,3 @@
-FOLDER=${FOLDER:-.}
-
 function create_cert() {
   local readonly name=$1
   local readonly folder=$2

--- a/prep_controlplane_values.sh
+++ b/prep_controlplane_values.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+FOLDER=${FOLDER:-.}
+
 cat > "${FOLDER}/cluster-$CLUSTER_NAME.yaml" <<EOF
 ---
 apiVersion: api.tsb.tetrate.io/v2

--- a/prep_controlplane_values.sh
+++ b/prep_controlplane_values.sh
@@ -1,9 +1,5 @@
-tctl config clusters set helm --tls-insecure --bridge-address $TSB_FQDN:8443
-tctl config users set helm --username admin --password "Tetrate123" --org "tetrate"
-tctl config profiles set helm --cluster helm --username helm
-tctl config profiles set-current helm
 
-cat > "${FOLDER}/$CLUSTER_NAME.yaml" <<EOF
+cat > "${FOLDER}/cluster-$CLUSTER_NAME.yaml" <<EOF
 ---
 apiVersion: api.tsb.tetrate.io/v2
 kind: Cluster
@@ -15,7 +11,7 @@ spec:
   tier1Cluster: false
 EOF
 
-tctl apply -f "${FOLDER}/$CLUSTER_NAME.yaml" 
+tctl apply -f "${FOLDER}/cluster-$CLUSTER_NAME.yaml"
 
 tctl install cluster-service-account --cluster $CLUSTER_NAME > $CLUSTER_NAME-service-account.jwk
 
@@ -25,7 +21,7 @@ export TSB_KEY=$(cat tsb_certs.key)
 export XCP_CENTRAL_CERT=$(cat xcp-central-cert.crt)
 export XCP_CENTRAL_KEY=$(cat xcp-central-cert.key)
 
-cat >"${FOLDER}/controlplane_values.yaml" <<EOF
+cat >"${FOLDER}/${CLUSTER_NAME}-controlplane_values.yaml" <<EOF
 image:
   registry: $REGISTRY
   tag: 1.5.1
@@ -58,7 +54,7 @@ EOF
 
 yq -i '.secrets.elasticsearch.cacert = strenv(CA_CRT) |
        .secrets.tsb.cacert = strenv(CA_CRT) |
-       .secrets.xcp.rootca = strenv(CA_CRT)' controlplane_values.yaml
+       .secrets.xcp.rootca = strenv(CA_CRT)' "${CLUSTER_NAME}-controlplane_values.yaml"
 
 cat >"${FOLDER}/dataplane_values.yaml" <<EOF
 image:

--- a/prep_controlplane_values.sh
+++ b/prep_controlplane_values.sh
@@ -1,8 +1,3 @@
-#!/bin/sh
-
-FOLDER=${FOLDER:-.}
-ORG=${ORG:-tetrate}
-
 cat > "${FOLDER}/cluster-$CLUSTER_NAME.yaml" <<EOF
 ---
 apiVersion: api.tsb.tetrate.io/v2

--- a/prep_controlplane_values.sh
+++ b/prep_controlplane_values.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 FOLDER=${FOLDER:-.}
+ORG=${ORG:-tetrate}
 
 cat > "${FOLDER}/cluster-$CLUSTER_NAME.yaml" <<EOF
 ---

--- a/prep_controlplane_values.sh
+++ b/prep_controlplane_values.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 
 cat > "${FOLDER}/cluster-$CLUSTER_NAME.yaml" <<EOF
 ---
@@ -8,7 +9,7 @@ metadata:
   organization: $ORG
 spec:
   tokenTtl: "87600h"
-  tier1Cluster: false
+  tier1Cluster: ${TIER1:-false}
 EOF
 
 tctl apply -f "${FOLDER}/cluster-$CLUSTER_NAME.yaml"

--- a/prep_managementplane_values.sh
+++ b/prep_managementplane_values.sh
@@ -4,6 +4,8 @@ export TSB_KEY=$(cat tsb_certs.key)
 export XCP_CENTRAL_CERT=$(cat xcp-central-cert.crt)
 export XCP_CENTRAL_KEY=$(cat xcp-central-cert.key)
 
+FOLDER=${FOLDER:-.}
+
 cat >"${FOLDER}/managementplane_values.yaml" <<EOF
 image:
   registry: $REGISTRY

--- a/prep_managementplane_values.sh
+++ b/prep_managementplane_values.sh
@@ -4,9 +4,6 @@ export TSB_KEY=$(cat tsb_certs.key)
 export XCP_CENTRAL_CERT=$(cat xcp-central-cert.crt)
 export XCP_CENTRAL_KEY=$(cat xcp-central-cert.key)
 
-FOLDER=${FOLDER:-.}
-ORG=${ORG:-tetrate}
-
 cat >"${FOLDER}/managementplane_values.yaml" <<EOF
 image:
   registry: $REGISTRY

--- a/prep_managementplane_values.sh
+++ b/prep_managementplane_values.sh
@@ -5,6 +5,7 @@ export XCP_CENTRAL_CERT=$(cat xcp-central-cert.crt)
 export XCP_CENTRAL_KEY=$(cat xcp-central-cert.key)
 
 FOLDER=${FOLDER:-.}
+ORG=${ORG:-tetrate}
 
 cat >"${FOLDER}/managementplane_values.yaml" <<EOF
 image:


### PR DESCRIPTION
- adds a `.gitignore` file to ignore generated files
- place instructions to 'connect to mp' in readme before the section on 'connecting to cp'
- make the name of the controlplane-values file unique to each cluster so that when adding more than one controlplane cluster, the values files are preserved and not overwritten.