### PR TITLE
- [might as well] use ORG var in cert generation

### DIFF
--- a/certs-gen/certs-gen.sh
+++ b/certs-gen/certs-gen.sh
@@ -45,7 +45,7 @@ x509_extensions    = req_ext
 [ req_distinguished_name ]
 countryName         = US
 stateOrProvinceName = CA
-organizationName    = Example
+organizationName    = $ORG
 commonName          = SelfSignedRootCA
 [ req_ext ]
 subjectKeyIdentifier = hash
@@ -86,7 +86,7 @@ x509_extensions    = req_ext
 [ req_distinguished_name ]
 countryName         = US
 stateOrProvinceName = CA
-organizationName    = Example
+organizationName    = $ORG
 commonName          = Example TSB Envoy GUI
 [ req_ext ]
 subjectKeyIdentifier = hash
@@ -119,7 +119,7 @@ x509_extensions    = req_ext
 [ req_distinguished_name ]
 countryName         = US
 stateOrProvinceName = CA
-organizationName    = Example
+organizationName    = $ORG
 commonName          = XCP Central
 # you will have to use 'extendedKeyUsage = serverAuth, clientAuth' because it will be checked by the TSB.
 [ req_ext ]

--- a/prep_controlplane_values.sh
+++ b/prep_controlplane_values.sh
@@ -1,4 +1,8 @@
-cat > "${FOLDER}/cluster-$CLUSTER_NAME.yaml" <<EOF
+#!/bin/bash
+
+# awk cmd taken from https://www.starkandwayne.com/blog/bashing-your-yaml/
+
+cat << EOF > "$FOLDER/cluster-$CLUSTER_NAME.yaml"
 ---
 apiVersion: api.tsb.tetrate.io/v2
 kind: Cluster
@@ -10,30 +14,27 @@ spec:
   tier1Cluster: ${TIER1:-false}
 EOF
 
-tctl apply -f "${FOLDER}/cluster-$CLUSTER_NAME.yaml"
+tctl apply -f "$FOLDER/cluster-$CLUSTER_NAME.yaml"
 
 tctl install cluster-service-account --cluster $CLUSTER_NAME > $CLUSTER_NAME-service-account.jwk
 
-export CA_CRT=$(cat ca.crt)
-export TSB_CRT=$(cat tsb_certs.crt)
-export TSB_KEY=$(cat tsb_certs.key)
-export XCP_CENTRAL_CERT=$(cat xcp-central-cert.crt)
-export XCP_CENTRAL_KEY=$(cat xcp-central-cert.key)
-
-cat >"${FOLDER}/${CLUSTER_NAME}-controlplane_values.yaml" <<EOF
+cat << EOF > "$FOLDER/$CLUSTER_NAME-controlplane_values.yaml"
 image:
   registry: $REGISTRY
-  tag: 1.5.1
+  tag: 1.5.2
 secrets:
   clusterServiceAccount:
-    JWK: '`cat $CLUSTER_NAME-service-account.jwk`'
+    JWK: '$(cat $CLUSTER_NAME-service-account.jwk)'
     clusterFQN: organizations/$ORG/clusters/$CLUSTER_NAME
   elasticsearch:
     cacert: |
+$(awk '{printf "      %s\n", $0}' < ca.crt)
   tsb:
     cacert: |  
+$(awk '{printf "      %s\n", $0}' < ca.crt)
   xcp: 
     rootca: |
+$(awk '{printf "      %s\n", $0}' < ca.crt)
 spec:
   hub: $REGISTRY
   managementPlane:
@@ -51,12 +52,8 @@ spec:
       version: 7
 EOF
 
-yq -i '.secrets.elasticsearch.cacert = strenv(CA_CRT) |
-       .secrets.tsb.cacert = strenv(CA_CRT) |
-       .secrets.xcp.rootca = strenv(CA_CRT)' "${CLUSTER_NAME}-controlplane_values.yaml"
-
-cat >"${FOLDER}/dataplane_values.yaml" <<EOF
+cat << EOF > "$FOLDER/dataplane_values.yaml"
 image:
   registry: $REGISTRY
-  tag: 1.5.1
+  tag: 1.5.2
 EOF

--- a/prep_managementplane_values.sh
+++ b/prep_managementplane_values.sh
@@ -1,13 +1,10 @@
-export CA_CRT=$(cat ca.crt)
-export TSB_CRT=$(cat tsb_certs.crt)
-export TSB_KEY=$(cat tsb_certs.key)
-export XCP_CENTRAL_CERT=$(cat xcp-central-cert.crt)
-export XCP_CENTRAL_KEY=$(cat xcp-central-cert.key)
 
-cat >"${FOLDER}/managementplane_values.yaml" <<EOF
+# awk cmd taken from https://www.starkandwayne.com/blog/bashing-your-yaml/
+
+cat >"$FOLDER/managementplane_values.yaml" <<EOF
 image:
   registry: $REGISTRY
-  tag: 1.5.1
+  tag: 1.5.2
 secrets:
   ldap:
     binddn: cn=admin,dc=tetrate,dc=io
@@ -18,20 +15,19 @@ secrets:
   tsb:
     adminPassword: Tetrate123
     cert: |   
+$(awk '{printf "      %s\n", $0}' < tsb_certs.crt)
     key: |  
+$(awk '{printf "      %s\n", $0}' < tsb_certs.key)
   xcp:
     autoGenerateCerts: false
     central:
       cert: |   
+$(awk '{printf "        %s\n", $0}' < xcp-central-cert.crt)
       key: |  
+$(awk '{printf "        %s\n", $0}' < xcp-central-cert.key)
     rootca: |
+$(awk '{printf "      %s\n", $0}' < ca.crt)
 spec:
   hub: $REGISTRY
   organization: $ORG
 EOF
-
-yq -i '.secrets.xcp.rootca = strenv(CA_CRT) |
-       .secrets.xcp.central.cert = strenv(XCP_CENTRAL_CERT) |
-       .secrets.xcp.central.key = strenv(XCP_CENTRAL_KEY) |
-       .secrets.tsb.cert = strenv(TSB_CRT) |
-       .secrets.tsb.key = strenv(TSB_KEY)'  managementplane_values.yaml


### PR DESCRIPTION
- directly expand certs into template with an awk command in lieu of yq trick
- update tag/version from 1.5.1 to 1.5.2